### PR TITLE
Allow customizations beyond data serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 .idea
+
+# VSCode specific settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -70,14 +70,39 @@ urlpatterns = [
 
 ## Customization
 This package allows you to specify the following when registering your model
-- `serializer`: A Model Serializer Class
+- `serializer_or_modeladmin`: A Model Serializer Class or a subclass of `RestModelAdmin`
 - ` permission_classes`: A list of Permission classes
 - `pagination_classs`: A Pagination Class
 
 An example of how a call to the register method with all 3 would look is :
 ```python
-restadmin.site.register(TestModel, serializer=AdminSerializer, permission_classes=[ReadOnly], 
+restadmin.site.register(TestModel, serializer_or_modeladmin=AdminSerializer, permission_classes=[ReadOnly], 
                         pagination_class=LargeResultsSetPagination)
+
+```
+
+`RestModelAdmin` expose the same interface as `ModelViewSet` so you can add the whole customizations that
+`ModelViewSet` offers. This includes:
+
+- Custom querysets
+- redifining defaults methods
+- add actions as ModelViewSet's exta actions
+
+You can also register models with the `register` decorator
+
+Example:
+```python
+from restadmin import register, RestModelAdmin
+from .models import TestModel
+
+@register(TestModel)
+class TestRestModelAdmin(RestModelAdmin):
+
+    serializer_class = MyCustomSerializer # Optional. A default is provided if None defined
+
+    def get_queryset(self):
+        queryset = TestModel.objects.filter(age__lt=30)
+        return queryset
 
 ```
 

--- a/restadmin/__init__.py
+++ b/restadmin/__init__.py
@@ -1,1 +1,3 @@
 from .sites import site
+from .decorators import register
+from .restmodeladmin import RestModelAdmin

--- a/restadmin/decorators.py
+++ b/restadmin/decorators.py
@@ -1,0 +1,34 @@
+def register(*models, site=None):
+    """
+    Register the given model(s) classes and wrapped ModelAdmin class with
+    admin site:
+
+    @register(Author)
+    class AuthorAdmin(admin.ModelAdmin):
+        pass
+
+    The `site` kwarg is an admin site to use instead of the default admin site.
+    """
+    from rest_framework.serializers import ModelSerializer
+    from .restmodeladmin import RestModelAdmin
+    from .sites import AdminSite
+    from .sites import site as default_site
+    
+
+    def _model_admin_wrapper(admin_class):
+        if not models:
+            raise ValueError("At least one model must be passed to register.")
+
+        admin_site = site or default_site
+
+        if not isinstance(admin_site, AdminSite):
+            raise ValueError("site must subclass AdminSite")
+
+        if not issubclass(admin_class, (RestModelAdmin, ModelSerializer)):
+            raise ValueError("Wrapped class must subclass RestModelAdmin or ModelSerializer.")
+
+        admin_site.register(models, serializer_or_modeladmin=admin_class)
+
+        return admin_class
+
+    return _model_admin_wrapper

--- a/restadmin/restmodeladmin.py
+++ b/restadmin/restmodeladmin.py
@@ -1,0 +1,13 @@
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAdminUser
+
+
+class RestModelAdmin(ModelViewSet):
+    """Equivalent to ModelAdmin, behave like a ModelViewSet
+    
+    This class is an abstraction layer between this packages
+    and using vanilla ModelViewSet. This will allow implementing
+    more features in the future
+    """
+    
+    permission_classes = [IsAdminUser] # By default allow admin users only

--- a/tests/restmodeladmin.py
+++ b/tests/restmodeladmin.py
@@ -1,0 +1,13 @@
+from restadmin import RestModelAdmin
+
+from .models import TestModel, SecondTestModel
+
+class TestRestModelAdmin(RestModelAdmin):
+    pass
+
+class SecondTestRestModelAdmin(RestModelAdmin):
+
+    def get_queryset(self):
+        queryset = SecondTestModel.objects.filter(age__lt=30)
+        return queryset
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,11 +2,14 @@ from rest_framework.test import APITestCase, override_settings, APIRequestFactor
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAdminUser
 from rest_framework.settings import api_settings
+from rest_framework.serializers import ModelSerializer
 from tests.models import TestModel, TestAbstractModel, SecondTestModel
 from tests.serializers import AdminSerializer
 from tests.permissions import ReadOnly
 from tests.pagination import LargeResultsSetPagination
+from tests.restmodeladmin import TestRestModelAdmin, SecondTestRestModelAdmin
 from restadmin.sites import AdminSite, AlreadyRegistered, NotRegistered
+from restadmin import register, RestModelAdmin
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import path, reverse
 from django.contrib.auth.models import User
@@ -84,9 +87,54 @@ class TestRegistration(APITestCase):
         self.site.register(TestModel)
         self.assertEqual(self.site._registry[TestModel].pagination_class, api_settings.DEFAULT_PAGINATION_CLASS)
 
+    def test_restmodeladmin_registration(self):
+        self.site.register(TestModel, TestRestModelAdmin)
+        self.assertEqual(self.site._registry[TestModel], TestRestModelAdmin)
+
+    def test_restmodeladmin_defaults(self):
+        self.site.register(TestModel, TestRestModelAdmin)
+        # Add some data
+        for i in [10, 20, 30, 40, 50, 60]:
+            TestModel.objects.create(age=i, name=str(i))
+        self.assertQuerysetEqual(self.site._registry[TestModel].queryset, TestModel.objects.all(), ordered=False)
+        self.assertEqual(self.site._registry[TestModel].serializer_class.__name__, 'TestModelSerializer')
+
+    def test_register_decorator(self):
+        @register(TestModel, site=self.site)
+        class DecoratorRestModelAdmin(RestModelAdmin):
+            pass
+        self.assertEqual(self.site._registry[TestModel], DecoratorRestModelAdmin)
+
+    def test_register_decorator_with_serializer(self):
+        @register(TestModel, site=self.site)
+        class DecoratorSerializer(ModelSerializer):
+            class Meta:
+                model = TestModel
+                fields = ["id"]
+        
+        self.assertEqual(self.site._registry[TestModel].serializer_class, DecoratorSerializer)
+
+    def test_register_decorator_with_not_models(self):
+        with self.assertRaises(ValueError):
+            @register()
+            class Foo: pass
+
+    def test_register_decorator_with_invalid_admin_site(self):
+        with self.assertRaises(ValueError):
+            @register(TestModel, site=True)
+            class Foo: pass
+
+    def test_register_decorator_with_invalid_class(self):
+        with self.assertRaises(ValueError):
+            @register(TestModel)
+            class Foo: pass
+
+
 
 site = AdminSite()
 site.register(TestModel)
+
+register(SecondTestModel, site=site)(SecondTestRestModelAdmin)
 
 urlpatterns = [
     path("test_admin/", site.urls),
@@ -149,3 +197,34 @@ class TestViewSets(APITestCase):
         url = reverse("restadmin:admin_TestModel-detail", args=(1,))
         response = self.client.delete(url)
         self.assertEqual(TestModel.objects.count(), 0)
+
+    def test_restmodeladmin_list_objects(self):
+        # Add some data
+        for i in [10, 20, 30, 40, 50, 60]:
+            SecondTestModel.objects.create(age=i, name=str(i))
+        url = reverse("restadmin:admin_SecondTestModel-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 2)
+    
+    def test_restmodeladmin_create_model_endpoint(self):
+        url = reverse("restadmin:admin_SecondTestModel-list")
+        response = self.client.post(url, data={"name": "name", "age": 16})
+        self.assertEqual(SecondTestModel.objects.count(), 1)
+        self.assertEqual(response.status_code, 201)
+
+    def test_restmodeladmin_update_model_endpoint(self):
+        model_object = SecondTestModel.objects.create(name="name1", age=5)
+        url = reverse("restadmin:admin_SecondTestModel-detail", args=(model_object.id,))
+        response = self.client.put(url, data={"name": "name2", "age": 15})
+        new_object = SecondTestModel.objects.get(id=model_object.id)
+        self.assertEqual(new_object.age, 15)
+        self.assertEqual(new_object.name, "name2")
+
+    def test_restmodeladmin_partial_update_model_endpoint(self):
+        model_object = SecondTestModel.objects.create(name="name1", age=5)
+        url = reverse("restadmin:admin_SecondTestModel-detail", args=(model_object.id,))
+        response = self.client.patch(url, data={"age": 15})
+        new_object = SecondTestModel.objects.get(id=model_object.id)
+        self.assertEqual(new_object.age, 15)
+        

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -61,7 +61,7 @@ class TestRegistration(APITestCase):
         self.assertTrue(issubclass(self.site._registry[SecondTestModel], ModelViewSet))
 
     def test_custom_serializer_registration(self):
-        self.site.register(TestModel, serializer=AdminSerializer)
+        self.site.register(TestModel, serializer_or_modeladmin=AdminSerializer)
         self.assertEqual(self.site._registry[TestModel].serializer_class, AdminSerializer)
 
     def test_custom_permission_class_registration(self):


### PR DESCRIPTION
Introduce RestModelAdmin class as an abstraction layer between this packages
and using vanilla ModelViewSet. Is an equivalent to Django's ModelAdmin and behave like Django Rest Framework's ModelViewSet.

New feautes:
Queryset customization
Redifine defaults methods
Add actions as ModelViewSet's exta actions
Powered by defaults so no much extra configuration needed
Backward compatibility
Also a register decorator is added similar to Django's admin.